### PR TITLE
install unversioned lib

### DIFF
--- a/ubuntu/debian/libignition-rendering-ogre1-dev.install
+++ b/ubuntu/debian/libignition-rendering-ogre1-dev.install
@@ -3,4 +3,5 @@ usr/include/ignition/rendering[0-99]/ignition/rendering/ogre.hh
 usr/lib/*/libignition-rendering[0-99]-ogre.so
 usr/lib/*/pkgconfig/ignition-rendering[0-99]-ogre.pc
 usr/lib/*/cmake/ignition-rendering[0-99]-ogre/*
+usr/lib/*/ign-rendering-[0-99]/engine-plugins/libignition-rendering*-ogre.so
 usr/share/ignition/ignition-rendering[0-99]/ogre/*

--- a/ubuntu/debian/libignition-rendering-ogre1.install
+++ b/ubuntu/debian/libignition-rendering-ogre1.install
@@ -1,1 +1,2 @@
 usr/lib/*/libignition-rendering[0-99]-ogre.so.*
+usr/lib/*/ign-rendering-[0-99]/engine-plugins/libignition-rendering*-ogre.so.*

--- a/ubuntu/debian/libignition-rendering-ogre2-dev.install
+++ b/ubuntu/debian/libignition-rendering-ogre2-dev.install
@@ -3,4 +3,5 @@ usr/include/ignition/rendering[0-99]/ignition/rendering/ogre2.hh
 usr/lib/*/libignition-rendering[0-99]-ogre2.so
 usr/lib/*/pkgconfig/ignition-rendering[0-99]-ogre2.pc
 usr/lib/*/cmake/ignition-rendering[0-99]-ogre2/*
+usr/lib/*/ign-rendering-[0-99]/engine-plugins/libignition-rendering*-ogre2*.so
 usr/share/ignition/ignition-rendering[0-99]/ogre2/*

--- a/ubuntu/debian/libignition-rendering-ogre2.install
+++ b/ubuntu/debian/libignition-rendering-ogre2.install
@@ -1,1 +1,2 @@
 usr/lib/*/libignition-rendering[0-99]-ogre2.so.*
+usr/lib/*/ign-rendering-[0-99]/engine-plugins/libignition-rendering*-ogre2*.so.*

--- a/ubuntu/debian/libignition-rendering-ogre2.install.install
+++ b/ubuntu/debian/libignition-rendering-ogre2.install.install
@@ -1,1 +1,2 @@
 usr/lib/*/libignition-rendering[0-99]-ogre2.so.*
+usr/lib/*/ign-rendering-[0-99]/engine-plugins/libignition-rendering*-ogre2*.so.*


### PR DESCRIPTION
Similar to ignition-release/ign-rendering3-release#1 and ignition-release/ign-rendering4-release#3, since the nightly builds are unstable:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering5-debbuilder&build=15)](https://build.osrfoundation.org/job/ign-rendering5-debbuilder/15/) https://build.osrfoundation.org/job/ign-rendering5-debbuilder/15/

with this branch:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering5-debbuilder&build=17)](https://build.osrfoundation.org/job/ign-rendering5-debbuilder/17/) https://build.osrfoundation.org/job/ign-rendering5-debbuilder/17/